### PR TITLE
Label a location by its name

### DIFF
--- a/kcp/nginx/scheduling/locations.yaml
+++ b/kcp/nginx/scheduling/locations.yaml
@@ -4,6 +4,7 @@ kind: Location
 metadata:
   name: green
   labels:
+    name: green
     color: green
 spec:
   instanceSelector:
@@ -19,6 +20,7 @@ kind: Location
 metadata:
   name: blue
   labels:
+    name: blue
     color: blue
 spec:
   instanceSelector:


### PR DESCRIPTION
This trick allows a location to be selected by a label selector once its name is known. It is used by our implementation of edge placement controller.