### PR TITLE
Add EdgePlacement for the edge-mc demo

### DIFF
--- a/edge-mc/README.md
+++ b/edge-mc/README.md
@@ -1,0 +1,11 @@
+#### Create Argo CD Application against edge-mc's Workload Management Workspace (WMW)
+
+The command and output should be similar to
+```console
+$ argocd app create edgeplacement \
+--repo https://github.com/edge-experiments/gitops-source.git \
+--path edge-mc/placement/ \
+--dest-server https://172.31.31.125:41973/clusters/root:my-org:wmw-1 \
+--sync-policy automated
+application 'edgeplacement' created
+```

--- a/edge-mc/placement/edgeplacements.yaml
+++ b/edge-mc/placement/edgeplacements.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: edge.kcp.io/v1alpha1
+kind: EdgePlacement
+metadata:
+  name: optimized
+spec:
+  locationSelectors:
+  - matchLabels:
+      aisle: "1"
+  namespaceSelector:
+    matchLabels:
+      optimizer: turbonomic


### PR DESCRIPTION
This PR creates an EdgePlacement object as a source for GitOps.

This EdgePlacement can be used as the interface, between the optimization of Turbonomic and the placement of edge-mc.